### PR TITLE
Queen moves implementation

### DIFF
--- a/include/chess_engine/attacks/queen.hpp
+++ b/include/chess_engine/attacks/queen.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <array>
+#include <chess_engine/attacks/bishop.hpp>
+#include <chess_engine/attacks/rook.hpp>
+#include <chess_engine/bitboard.hpp>
+#include <chess_engine/bitmasks.hpp>
+#include <cstdint>
+
+namespace Attacks {
+
+/**
+ * @brief Generates a bitboard of all squares a queen can attack from the given square in all directions.
+ * @param sq The square index (0-63).
+ * @return Bitboard of all squares attacked by a queen from the given square.
+ *
+ * Note that queen moves is the combination of rook and bishop moves.
+ */
+constexpr uint64_t queen_attacks_for_square(int sq) {
+  return rook_attacks_for_square(sq) | bishop_attacks_for_square(sq);
+}
+
+/**
+ * @brief Precomputed lookup table of queen attacks for every square on the board.
+ *
+ * Each entry is a bitboard of all squares a queen can attack from the corresponding square.
+ * Indexed by square (0-63).
+ */
+constexpr std::array<Bitboard, 64> QUEEN_ATTACKS = []() constexpr {
+  std::array<Bitboard, 64> table{};
+  for (int sq = 0; sq < 64; ++sq) {
+    table[sq] = Bitboard(queen_attacks_for_square(sq));
+  }
+  return table;
+}();
+
+}  // namespace Attacks

--- a/tests/chess_engine/attacks/test_attacks_queen.cpp
+++ b/tests/chess_engine/attacks/test_attacks_queen.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+
+#include <chess_engine/attacks/queen.hpp>
+#include <chess_engine/bitboard.hpp>
+#include <chess_engine/square.hpp>
+
+TEST(QueenAttacksTest, CornerA1) {
+  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::A1];
+
+  Bitboard expected = Bitboard(Bitmasks::FILE_A | Bitmasks::RANK_1);
+  expected.clear(Square::A1);
+
+  EXPECT_EQ(bb & (Bitmasks::FILE_A | Bitmasks::RANK_1), expected);
+
+  EXPECT_TRUE(bb.test(Square::B2));
+  EXPECT_TRUE(bb.test(Square::C3));
+  EXPECT_TRUE(bb.test(Square::D4));
+  EXPECT_TRUE(bb.test(Square::E5));
+  EXPECT_TRUE(bb.test(Square::F6));
+  EXPECT_TRUE(bb.test(Square::G7));
+  EXPECT_TRUE(bb.test(Square::H8));
+}
+
+TEST(QueenAttacksTest, CornerA8) {
+  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::A8];
+
+  Bitboard expected = Bitboard(Bitmasks::FILE_A | Bitmasks::RANK_8);
+  expected.clear(Square::A8);
+
+  EXPECT_EQ(bb & (Bitmasks::FILE_A | Bitmasks::RANK_8), expected);
+
+  EXPECT_TRUE(bb.test(Square::B7));
+  EXPECT_TRUE(bb.test(Square::C6));
+  EXPECT_TRUE(bb.test(Square::D5));
+  EXPECT_TRUE(bb.test(Square::E4));
+  EXPECT_TRUE(bb.test(Square::F3));
+  EXPECT_TRUE(bb.test(Square::G2));
+  EXPECT_TRUE(bb.test(Square::H1));
+}
+
+TEST(QueenAttacksTest, CornerH1) {
+  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::H1];
+
+  Bitboard expected = Bitboard(Bitmasks::FILE_H | Bitmasks::RANK_1);
+  expected.clear(Square::H1);
+
+  EXPECT_EQ(bb & (Bitmasks::FILE_H | Bitmasks::RANK_1), expected);
+
+  EXPECT_TRUE(bb.test(Square::A8));
+  EXPECT_TRUE(bb.test(Square::B7));
+  EXPECT_TRUE(bb.test(Square::C6));
+  EXPECT_TRUE(bb.test(Square::D5));
+  EXPECT_TRUE(bb.test(Square::E4));
+  EXPECT_TRUE(bb.test(Square::F3));
+  EXPECT_TRUE(bb.test(Square::G2));
+}
+
+TEST(QueenAttacksTest, CornerH8) {
+  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::H8];
+
+  Bitboard expected = Bitboard(Bitmasks::FILE_H | Bitmasks::RANK_8);
+  expected.clear(Square::H8);
+
+  EXPECT_EQ(bb & (Bitmasks::FILE_H | Bitmasks::RANK_8), expected);
+
+  EXPECT_TRUE(bb.test(Square::A1));
+  EXPECT_TRUE(bb.test(Square::B2));
+  EXPECT_TRUE(bb.test(Square::C3));
+  EXPECT_TRUE(bb.test(Square::D4));
+  EXPECT_TRUE(bb.test(Square::E5));
+  EXPECT_TRUE(bb.test(Square::F6));
+  EXPECT_TRUE(bb.test(Square::G7));
+}
+
+TEST(QueenAttacksTest, CenterD4) {
+  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::D4];
+
+  Bitboard expected = Bitboard(Bitmasks::FILE_D | Bitmasks::RANK_4);
+  expected.clear(Square::D4);
+
+  EXPECT_EQ(bb & (Bitmasks::FILE_D | Bitmasks::RANK_4), expected);
+
+  // Towards NE
+  EXPECT_TRUE(bb.test(Square::E5));
+  EXPECT_TRUE(bb.test(Square::F6));
+  EXPECT_TRUE(bb.test(Square::G7));
+  EXPECT_TRUE(bb.test(Square::H8));
+
+  // Towards NW
+  EXPECT_TRUE(bb.test(Square::C5));
+  EXPECT_TRUE(bb.test(Square::B6));
+  EXPECT_TRUE(bb.test(Square::A7));
+
+  // Towards SE
+  EXPECT_TRUE(bb.test(Square::E3));
+  EXPECT_TRUE(bb.test(Square::F2));
+  EXPECT_TRUE(bb.test(Square::G1));
+
+  // Towards SW
+  EXPECT_TRUE(bb.test(Square::C3));
+  EXPECT_TRUE(bb.test(Square::B2));
+  EXPECT_TRUE(bb.test(Square::A1));
+}


### PR DESCRIPTION
# 📌 Queen moves implementation

## 📄 Description

Implemented queen moves generated at compile time like other piece's moves.
This is the last piece move generation before going a bit more high level with moves (at least I hope little refactoring will be needed).

## 🧩 Type of Change

- ✨ New feature
- ✅ Test addition or update

## 🔖 Release

- 🚫 None — Does not affect the public API or functionality
