### PR TITLE
Renaming `Attacks` namespace to `Lookups`

### DIFF
--- a/include/bitbishop/lookups/bishop.hpp
+++ b/include/bitbishop/lookups/bishop.hpp
@@ -4,7 +4,7 @@
 #include <bitbishop/bitmasks.hpp>
 #include <cstdint>
 
-namespace Attacks {
+namespace Lookups {
 
 /**
  * @brief Generates a bitboard of all squares a bishop can attack moving northeast from the given square.
@@ -98,4 +98,4 @@ constexpr std::array<Bitboard, 64> BISHOP_ATTACKS = []() constexpr {
   return table;
 }();
 
-}  // namespace Attacks
+}  // namespace Lookups

--- a/include/bitbishop/lookups/king.hpp
+++ b/include/bitbishop/lookups/king.hpp
@@ -4,7 +4,7 @@
 #include <bitbishop/bitmasks.hpp>
 #include <cstdint>
 
-namespace Attacks {
+namespace Lookups {
 
 /**
  * @brief Computes the attack bitboard for a king on a given square.
@@ -53,4 +53,4 @@ constexpr std::array<Bitboard, 64> KING_ATTACKS = []() constexpr {
   return table;
 }();
 
-}  // namespace Attacks
+}  // namespace Lookups

--- a/include/bitbishop/lookups/knight.hpp
+++ b/include/bitbishop/lookups/knight.hpp
@@ -4,7 +4,7 @@
 #include <bitbishop/bitmasks.hpp>
 #include <cstdint>
 
-namespace Attacks {
+namespace Lookups {
 
 /**
  * @brief Computes the attack bitboard for a knight on a given square.
@@ -47,4 +47,4 @@ constexpr std::array<Bitboard, 64> KNIGHT_ATTACKS = []() constexpr {
   return table;
 }();
 
-}  // namespace Attacks
+}  // namespace Lookups

--- a/include/bitbishop/lookups/pawn.hpp
+++ b/include/bitbishop/lookups/pawn.hpp
@@ -4,7 +4,7 @@
 #include <bitbishop/bitmasks.hpp>
 #include <cstdint>
 
-namespace Attacks {
+namespace Lookups {
 
 /**
  * @brief Precomputed bitboards for white pawn single pushes (1 square forward).
@@ -120,4 +120,4 @@ constexpr std::array<Bitboard, 64> BLACK_PAWN_ATTACKS = []() constexpr {
   return table;
 }();
 
-}  // namespace Attacks
+}  // namespace Lookups

--- a/include/bitbishop/lookups/queen.hpp
+++ b/include/bitbishop/lookups/queen.hpp
@@ -6,7 +6,7 @@
 #include <bitbishop/lookups/rook.hpp>
 #include <cstdint>
 
-namespace Attacks {
+namespace Lookups {
 
 /**
  * @brief Generates a bitboard of all squares a queen can attack from the given square in all directions.
@@ -33,4 +33,4 @@ constexpr std::array<Bitboard, 64> QUEEN_ATTACKS = []() constexpr {
   return table;
 }();
 
-}  // namespace Attacks
+}  // namespace Lookups

--- a/include/bitbishop/lookups/rook.hpp
+++ b/include/bitbishop/lookups/rook.hpp
@@ -4,7 +4,7 @@
 #include <bitbishop/bitmasks.hpp>
 #include <cstdint>
 
-namespace Attacks {
+namespace Lookups {
 
 /**
  * @brief Generates a bitboard of all squares a rook can attack moving north from the given square.
@@ -89,4 +89,4 @@ constexpr std::array<Bitboard, 64> ROOK_ATTACKS = []() constexpr {
   return table;
 }();
 
-}  // namespace Attacks
+}  // namespace Lookups

--- a/include/bitbishop/moves/pawn_move_gen.hpp
+++ b/include/bitbishop/moves/pawn_move_gen.hpp
@@ -119,9 +119,9 @@ constexpr bool can_capture_en_passant(Square from, Square epsq, Color side) noex
 constexpr std::array<Bitboard, 64> single_push(Color side) {
   switch (side) {
     case Color::WHITE:
-      return Attacks::WHITE_PAWN_SINGLE_PUSH;
+      return Lookups::WHITE_PAWN_SINGLE_PUSH;
     case Color::BLACK:
-      return Attacks::BLACK_PAWN_SINGLE_PUSH;
+      return Lookups::BLACK_PAWN_SINGLE_PUSH;
   }
   std::unreachable();
 }
@@ -143,9 +143,9 @@ constexpr std::array<Bitboard, 64> single_push(Color side) {
 constexpr std::array<Bitboard, 64> double_push(Color side) {
   switch (side) {
     case Color::WHITE:
-      return Attacks::WHITE_PAWN_DOUBLE_PUSH;
+      return Lookups::WHITE_PAWN_DOUBLE_PUSH;
     case Color::BLACK:
-      return Attacks::BLACK_PAWN_DOUBLE_PUSH;
+      return Lookups::BLACK_PAWN_DOUBLE_PUSH;
   }
   std::unreachable();
 }
@@ -167,9 +167,9 @@ constexpr std::array<Bitboard, 64> double_push(Color side) {
 constexpr std::array<Bitboard, 64> captures(Color side) {
   switch (side) {
     case Color::WHITE:
-      return Attacks::WHITE_PAWN_ATTACKS;
+      return Lookups::WHITE_PAWN_ATTACKS;
     case Color::BLACK:
-      return Attacks::BLACK_PAWN_ATTACKS;
+      return Lookups::BLACK_PAWN_ATTACKS;
   }
   std::unreachable();
 }

--- a/src/bitbishop/moves/king_move_gen.cpp
+++ b/src/bitbishop/moves/king_move_gen.cpp
@@ -18,7 +18,7 @@ void KingMoveGenerator::generate_pseudo_legal_moves(std::vector<Move>& moves, co
   }
 
   const Square from = opt_sq.value();
-  const Bitboard king_moves = Attacks::KING_ATTACKS[from.value()];
+  const Bitboard king_moves = Lookups::KING_ATTACKS[from.value()];
   const Bitboard empty = board.unoccupied();
   const Bitboard enemy = board.enemy(side);
 

--- a/tests/bitbishop/lookups/test_attacks_bishop.cpp
+++ b/tests/bitbishop/lookups/test_attacks_bishop.cpp
@@ -5,7 +5,7 @@
 #include <bitbishop/square.hpp>
 
 TEST(BishopAttacksTest, CornerA1) {
-  Bitboard bb = Attacks::BISHOP_ATTACKS[Square::A1];
+  Bitboard bb = Lookups::BISHOP_ATTACKS[Square::A1];
 
   EXPECT_TRUE(bb.test(Square::B2));
   EXPECT_TRUE(bb.test(Square::C3));
@@ -17,7 +17,7 @@ TEST(BishopAttacksTest, CornerA1) {
 }
 
 TEST(BishopAttacksTest, CornerA8) {
-  Bitboard bb = Attacks::BISHOP_ATTACKS[Square::A8];
+  Bitboard bb = Lookups::BISHOP_ATTACKS[Square::A8];
 
   EXPECT_TRUE(bb.test(Square::B7));
   EXPECT_TRUE(bb.test(Square::C6));
@@ -29,7 +29,7 @@ TEST(BishopAttacksTest, CornerA8) {
 }
 
 TEST(BishopAttacksTest, CornerH1) {
-  Bitboard bb = Attacks::BISHOP_ATTACKS[Square::H1];
+  Bitboard bb = Lookups::BISHOP_ATTACKS[Square::H1];
 
   EXPECT_TRUE(bb.test(Square::A8));
   EXPECT_TRUE(bb.test(Square::B7));
@@ -41,7 +41,7 @@ TEST(BishopAttacksTest, CornerH1) {
 }
 
 TEST(BishopAttacksTest, CornerH8) {
-  Bitboard bb = Attacks::BISHOP_ATTACKS[Square::H8];
+  Bitboard bb = Lookups::BISHOP_ATTACKS[Square::H8];
 
   EXPECT_TRUE(bb.test(Square::A1));
   EXPECT_TRUE(bb.test(Square::B2));
@@ -53,7 +53,7 @@ TEST(BishopAttacksTest, CornerH8) {
 }
 
 TEST(BishopAttacksTest, CenterD4) {
-  Bitboard bb = Attacks::BISHOP_ATTACKS[Square::D4];
+  Bitboard bb = Lookups::BISHOP_ATTACKS[Square::D4];
 
   // Towards NE
   EXPECT_TRUE(bb.test(Square::E5));

--- a/tests/bitbishop/lookups/test_attacks_king.cpp
+++ b/tests/bitbishop/lookups/test_attacks_king.cpp
@@ -5,7 +5,7 @@
 #include <bitbishop/lookups/king.hpp>
 #include <bitbishop/square.hpp>
 
-using namespace Attacks;
+using namespace Lookups;
 
 /**
  * @test King attacks from A1 corner square.

--- a/tests/bitbishop/lookups/test_attacks_knight.cpp
+++ b/tests/bitbishop/lookups/test_attacks_knight.cpp
@@ -5,7 +5,7 @@
 #include <bitbishop/lookups/knight.hpp>
 #include <bitbishop/square.hpp>
 
-using namespace Attacks;
+using namespace Lookups;
 
 TEST(KnightAttackTest, CornerA1) {
   Bitboard expected;

--- a/tests/bitbishop/lookups/test_attacks_pawns.cpp
+++ b/tests/bitbishop/lookups/test_attacks_pawns.cpp
@@ -4,7 +4,7 @@
 #include <bitbishop/lookups/pawn.hpp>
 #include <bitbishop/square.hpp>
 
-using namespace Attacks;
+using namespace Lookups;
 
 /**
  * @test White pawn single push from A2

--- a/tests/bitbishop/lookups/test_attacks_queen.cpp
+++ b/tests/bitbishop/lookups/test_attacks_queen.cpp
@@ -5,7 +5,7 @@
 #include <bitbishop/square.hpp>
 
 TEST(QueenAttacksTest, CornerA1) {
-  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::A1];
+  Bitboard bb = Lookups::QUEEN_ATTACKS[Square::A1];
 
   Bitboard expected = Bitboard(Bitmasks::FILE_A | Bitmasks::RANK_1);
   expected.clear(Square::A1);
@@ -22,7 +22,7 @@ TEST(QueenAttacksTest, CornerA1) {
 }
 
 TEST(QueenAttacksTest, CornerA8) {
-  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::A8];
+  Bitboard bb = Lookups::QUEEN_ATTACKS[Square::A8];
 
   Bitboard expected = Bitboard(Bitmasks::FILE_A | Bitmasks::RANK_8);
   expected.clear(Square::A8);
@@ -39,7 +39,7 @@ TEST(QueenAttacksTest, CornerA8) {
 }
 
 TEST(QueenAttacksTest, CornerH1) {
-  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::H1];
+  Bitboard bb = Lookups::QUEEN_ATTACKS[Square::H1];
 
   Bitboard expected = Bitboard(Bitmasks::FILE_H | Bitmasks::RANK_1);
   expected.clear(Square::H1);
@@ -56,7 +56,7 @@ TEST(QueenAttacksTest, CornerH1) {
 }
 
 TEST(QueenAttacksTest, CornerH8) {
-  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::H8];
+  Bitboard bb = Lookups::QUEEN_ATTACKS[Square::H8];
 
   Bitboard expected = Bitboard(Bitmasks::FILE_H | Bitmasks::RANK_8);
   expected.clear(Square::H8);
@@ -73,7 +73,7 @@ TEST(QueenAttacksTest, CornerH8) {
 }
 
 TEST(QueenAttacksTest, CenterD4) {
-  Bitboard bb = Attacks::QUEEN_ATTACKS[Square::D4];
+  Bitboard bb = Lookups::QUEEN_ATTACKS[Square::D4];
 
   Bitboard expected = Bitboard(Bitmasks::FILE_D | Bitmasks::RANK_4);
   expected.clear(Square::D4);

--- a/tests/bitbishop/lookups/test_attacks_rook.cpp
+++ b/tests/bitbishop/lookups/test_attacks_rook.cpp
@@ -5,7 +5,7 @@
 #include <bitbishop/square.hpp>
 
 TEST(RookAttacksTest, CornerA1) {
-  Bitboard bb = Attacks::ROOK_ATTACKS[Square::A1];
+  Bitboard bb = Lookups::ROOK_ATTACKS[Square::A1];
 
   // A1 attacks consit in A file + rank 1 without A1
   Bitboard expected = Bitboard(Bitmasks::FILE_A | Bitmasks::RANK_1);
@@ -15,7 +15,7 @@ TEST(RookAttacksTest, CornerA1) {
 }
 
 TEST(RookAttacksTest, CornerA8) {
-  Bitboard bb = Attacks::ROOK_ATTACKS[Square::A8];
+  Bitboard bb = Lookups::ROOK_ATTACKS[Square::A8];
 
   // A8 attacks consit in A file + rank 8 without A8
   Bitboard expected = Bitboard(Bitmasks::FILE_A | Bitmasks::RANK_8);
@@ -25,7 +25,7 @@ TEST(RookAttacksTest, CornerA8) {
 }
 
 TEST(RookAttacksTest, CornerH1) {
-  Bitboard bb = Attacks::ROOK_ATTACKS[Square::H1];
+  Bitboard bb = Lookups::ROOK_ATTACKS[Square::H1];
 
   // H1 attacks consit in H file + rank 1 without H1
   Bitboard expected = Bitboard(Bitmasks::FILE_H | Bitmasks::RANK_1);
@@ -35,7 +35,7 @@ TEST(RookAttacksTest, CornerH1) {
 }
 
 TEST(RookAttacksTest, CornerH8) {
-  Bitboard bb = Attacks::ROOK_ATTACKS[Square::H8];
+  Bitboard bb = Lookups::ROOK_ATTACKS[Square::H8];
 
   // H8 attacks consit in H file + rank 8 without H8
   Bitboard expected = Bitboard(Bitmasks::FILE_H | Bitmasks::RANK_8);
@@ -45,7 +45,7 @@ TEST(RookAttacksTest, CornerH8) {
 }
 
 TEST(RookAttacksTest, CenterD4) {
-  Bitboard bb = Attacks::ROOK_ATTACKS[Square::D4];
+  Bitboard bb = Lookups::ROOK_ATTACKS[Square::D4];
 
   // D4 attacks consit in D file + rank 4 without D4
   Bitboard expected = Bitboard(Bitmasks::FILE_D | Bitmasks::RANK_4);

--- a/tests/bitbishop/moves/pawn_move_generator/test_pmg_captures.cpp
+++ b/tests/bitbishop/moves/pawn_move_generator/test_pmg_captures.cpp
@@ -8,7 +8,7 @@
 TEST(PawnMoveGeneratorTest, AttacksWhiteReturnsCorrectArray) {
   auto result = PawnMoveGenerator::captures(Color::WHITE);
   EXPECT_EQ(result.size(), 64);
-  EXPECT_EQ(result, Attacks::WHITE_PAWN_ATTACKS);
+  EXPECT_EQ(result, Lookups::WHITE_PAWN_ATTACKS);
 }
 
 /**
@@ -17,7 +17,7 @@ TEST(PawnMoveGeneratorTest, AttacksWhiteReturnsCorrectArray) {
 TEST(PawnMoveGeneratorTest, AttacksBlackReturnsCorrectArray) {
   auto result = PawnMoveGenerator::captures(Color::BLACK);
   EXPECT_EQ(result.size(), 64);
-  EXPECT_EQ(result, Attacks::BLACK_PAWN_ATTACKS);
+  EXPECT_EQ(result, Lookups::BLACK_PAWN_ATTACKS);
 }
 
 /**

--- a/tests/bitbishop/moves/pawn_move_generator/test_pmg_double_push.cpp
+++ b/tests/bitbishop/moves/pawn_move_generator/test_pmg_double_push.cpp
@@ -8,7 +8,7 @@
 TEST(PawnMoveGeneratorTest, DoublePushWhiteReturnsCorrectArray) {
   auto result = PawnMoveGenerator::double_push(Color::WHITE);
   EXPECT_EQ(result.size(), 64);
-  EXPECT_EQ(result, Attacks::WHITE_PAWN_DOUBLE_PUSH);
+  EXPECT_EQ(result, Lookups::WHITE_PAWN_DOUBLE_PUSH);
 }
 
 /**
@@ -17,7 +17,7 @@ TEST(PawnMoveGeneratorTest, DoublePushWhiteReturnsCorrectArray) {
 TEST(PawnMoveGeneratorTest, DoublePushBlackReturnsCorrectArray) {
   auto result = PawnMoveGenerator::double_push(Color::BLACK);
   EXPECT_EQ(result.size(), 64);
-  EXPECT_EQ(result, Attacks::BLACK_PAWN_DOUBLE_PUSH);
+  EXPECT_EQ(result, Lookups::BLACK_PAWN_DOUBLE_PUSH);
 }
 
 /**

--- a/tests/bitbishop/moves/pawn_move_generator/test_pmg_single_push.cpp
+++ b/tests/bitbishop/moves/pawn_move_generator/test_pmg_single_push.cpp
@@ -8,7 +8,7 @@
 TEST(PawnMoveGeneratorTest, SinglePushWhiteReturnsCorrectArray) {
   auto result = PawnMoveGenerator::single_push(Color::WHITE);
   EXPECT_EQ(result.size(), 64);
-  EXPECT_EQ(result, Attacks::WHITE_PAWN_SINGLE_PUSH);
+  EXPECT_EQ(result, Lookups::WHITE_PAWN_SINGLE_PUSH);
 }
 
 /**
@@ -17,7 +17,7 @@ TEST(PawnMoveGeneratorTest, SinglePushWhiteReturnsCorrectArray) {
 TEST(PawnMoveGeneratorTest, SinglePushBlackReturnsCorrectArray) {
   auto result = PawnMoveGenerator::single_push(Color::BLACK);
   EXPECT_EQ(result.size(), 64);
-  EXPECT_EQ(result, Attacks::BLACK_PAWN_SINGLE_PUSH);
+  EXPECT_EQ(result, Lookups::BLACK_PAWN_SINGLE_PUSH);
 }
 
 /**

--- a/tests/bitbishop/test_knight.cpp
+++ b/tests/bitbishop/test_knight.cpp
@@ -5,7 +5,7 @@
 #include <bitbishop/lookups/knight.hpp>
 #include <bitbishop/square.hpp>
 
-using namespace Attacks;
+using namespace Lookups;
 
 TEST(KnightAttackTest, CornerA1) {
   Bitboard expected;


### PR DESCRIPTION
# 📌 Renaming `Attacks` namespace to `Lookups`

## 🧩 Type of Change

- 🔨 Refactoring
- 🧹 Code cleanup
