### PR TITLE
Setting up Clang Tidy linting

### DIFF
--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -30,6 +30,7 @@ jobs:
         run: cmake --preset clang_debug
 
       - name: Run clang-tidy
+        shell: bash
         run: |
           set +e
           cmake --build --preset clang_debug --target clang-tidy 2>&1 | tee clang_tidy_output.txt


### PR DESCRIPTION
# 📌 Setting up Clang Tidy linting

## 📄 Description

Setting up Clang Tidy linting into a dedicated GitHub action.

## 🧩 Type of Change

- 🔧 Build or CI/CD configuration
