### PR TITLE
Using Ninja build tool for clang presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,6 +19,7 @@
     {
       "name": "clang_debug",
       "inherits": "default",
+      "generator": "Ninja",
       "description": "Debug build with debug symbols and no optimizations",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -28,6 +29,7 @@
     {
       "name": "clang_release",
       "inherits": "default",
+      "generator": "Ninja",
       "description": "Release build with optimizations",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",


### PR DESCRIPTION
# 📌 Using Ninja build tool for clang presets

## 📄 Description

Using Ninja build tool for clang presets to allow for parallel builds, therefore reducing runner time and local build time.

| cmake generator                           | make   | ninja  | github runner time gain |
|-------------------------------------------|--------|--------|-------------------------|
| build phase with clang_debug preset       | 3m 42s | 1m 14s | 2m 28s                  |
| build phase with clang_release preset     | 3m 36s | 1m 52s | 1m 44s                  |
| clang_tidy target with clang_debug preset | 3m 04s | 2m 41s | 23s                     |

## 🧩 Type of Change

- 🔧 Build or CI/CD configuration

