### PR TITLE
Implementing UCI `d` command

### DIFF
--- a/include/bitbishop/board.hpp
+++ b/include/bitbishop/board.hpp
@@ -131,7 +131,7 @@ class Board {
   void remove_piece(Square square);
 
   /**
-   * @brief Prints the board to the given output stream.
+   * @brief Prints the board to std::cout.
    *
    * Prints an ASCII board with ranks 8 → 1 and files A → H.
    * Example:
@@ -147,6 +147,8 @@ class Board {
    * @endcode
    */
   void print() const;
+
+  friend std::ostream& operator<<(std::ostream& out, const Board& board);
 
   /**
    * @brief Returns a bitboard containing all white pieces.
@@ -335,6 +337,12 @@ class Board {
   [[nodiscard]] bool has_insufficient_material() const noexcept;
 
   [[nodiscard]] Zobrist::Key get_zobrist_hash() const noexcept { return m_zobrist_hash; }
+
+  /**
+   * @brief Retrieves Board's FEN.
+   * @return FEN built from to the internal board representation.
+   */
+  [[nodiscard]] std::string get_fen() const noexcept;
 
   Board& operator=(const Board& other) noexcept = default;
   Board& operator=(Board&& other) noexcept = default;

--- a/include/bitbishop/interface/uci_engine.hpp
+++ b/include/bitbishop/interface/uci_engine.hpp
@@ -134,6 +134,16 @@ class UciEngine {
    * @brief Stops as soon as possible the search thread and resets it for later computations.
    */
   void reset_search_worker();
+
+  /**
+   * @brief Displays the current board state as well as usefull information.
+   *
+   * Other information includes:
+   *
+   * - FEN
+   * - Zobrist hash key
+   */
+  void handle_display();
 };
 
 }  // namespace Uci

--- a/src/bitbishop/board.cpp
+++ b/src/bitbishop/board.cpp
@@ -73,6 +73,31 @@ Board::Board(const std::string& fen) {
   m_zobrist_hash = Zobrist::compute_hash(*this);
 }
 
+std::ostream& operator<<(std::ostream& out, const Board& board) {
+  using namespace Const;
+
+  const std::string separator = "+---+---+---+---+---+---+---+---+\n";
+  const std::string files = "  a   b   c   d   e   f   g   h  \n";
+
+  out << "   " << files;
+  out << "   " << separator;
+  for (int rank = RANK_8_IND; rank >= RANK_1_IND; --rank) {
+    out << " " << (rank + 1) << " |";
+    for (int file = FILE_A_IND; file <= FILE_H_IND; ++file) {
+      Square square(file, rank);
+      std::optional<Piece> opt_p = board.get_piece(square);
+
+      const char piece_char = opt_p ? opt_p->to_char() : ' ';
+      out << " " << piece_char << " |";
+    }
+
+    out << " " << (rank + 1) << "\n";
+    out << "   " << separator;
+  }
+  out << "   " << files;
+  return out;
+}
+
 Bitboard Board::white_pieces() const {
   Bitboard bitboard;
   bitboard |= m_w_pawns;
@@ -207,21 +232,7 @@ void Board::remove_piece(Square square) {
   m_b_king.clear(square);
 }
 
-void Board::print() const {
-  using namespace Const;
-
-  for (int rank = RANK_8_IND; rank >= RANK_1_IND; --rank) {
-    std::cout << (rank + 1) << " ";  // rank numbers on the left
-    for (int file = FILE_A_IND; file <= FILE_H_IND; ++file) {
-      Square square(file, rank);
-      std::optional<Piece> opt_p = get_piece(square);
-      char character = (opt_p.has_value()) ? opt_p.value().to_char() : '.';
-      std::cout << character << " ";
-    }
-    std::cout << "\n";
-  }
-  std::cout << "  a b c d e f g h\n";  // file labels
-}
+void Board::print() const { std::cout << *this; }
 
 bool Board::can_castle_kingside(Color side) const noexcept {
   if (!this->has_kingside_castling_rights(side)) {
@@ -310,6 +321,66 @@ bool Board::has_insufficient_material() const noexcept {
   }
 
   return false;
+}
+
+std::string Board::get_fen() const noexcept {
+  using namespace Const;
+
+  std::string fen;
+  fen.reserve(FEN_NOTATION_MAX_CHAR_COUNT);
+
+  // Board position
+  for (int rank = RANK_8_IND; rank >= RANK_1_IND; --rank) {
+    std::size_t empty = 0;
+
+    for (int file = FILE_A_IND; file <= FILE_H_IND; ++file) {
+      const auto opt_p = get_piece(Square(file, rank));
+      if (opt_p) {
+        if (empty > 0) {
+          fen += std::to_string(empty);
+          empty = 0;
+        }
+        fen += opt_p->to_char();
+      } else {
+        ++empty;
+      }
+    }
+    if (empty > 0) {
+      fen += std::to_string(empty);
+    }
+    if (rank != RANK_1_IND) {
+      fen += "/";
+    }
+  }
+  fen += " ";
+
+  // Side to move
+  fen += (m_state.m_is_white_turn ? "w" : "b");
+  fen += " ";
+
+  // Castling availability
+  bool has_castling = false;
+  // clang-format off
+  if (m_state.m_white_castle_kingside)  { fen += 'K'; has_castling = true; }
+  if (m_state.m_white_castle_queenside) { fen += 'Q'; has_castling = true; }
+  if (m_state.m_black_castle_kingside)  { fen += 'k'; has_castling = true; }
+  if (m_state.m_black_castle_queenside) { fen += 'q'; has_castling = true; }
+  if (!has_castling) { fen += '-'; }
+  // clang-format on
+  fen += " ";
+
+  // En passant target
+  fen += (m_state.m_en_passant_sq ? m_state.m_en_passant_sq->to_string() : "-");
+  fen += " ";
+
+  // Halfmove clock
+  fen += std::to_string(m_state.m_halfmove_clock);
+  fen += " ";
+
+  // Fullmove number
+  fen += std::to_string(m_state.m_fullmove_number);
+
+  return fen;
 }
 
 bool Board::operator==(const Board& other) const {

--- a/src/bitbishop/interface/uci_engine.cpp
+++ b/src/bitbishop/interface/uci_engine.cpp
@@ -47,6 +47,8 @@ void Uci::UciEngine::dispatch(std::vector<std::string> &line) {
     handle_stop();
   } else if (line.front() == "quit") {
     handle_quit();
+  } else if (line.front() == "d") {
+    handle_display();
   }
   // unknown lines are discarded silently following uci rules
 };
@@ -160,4 +162,12 @@ void Uci::UciEngine::reset_search_worker() {
     search_worker_ptr.reset();
   }
   assert(search_worker_ptr == nullptr);
+}
+
+void Uci::UciEngine::handle_display() {
+  out_stream << "\n";
+  out_stream << board << "\n";
+  out_stream << "FEN notation: " << board.get_fen() << "\n";
+  out_stream << "Zobrist hash: " << board.get_zobrist_hash() << "\n";
+  out_stream << std::flush;
 }

--- a/tests/bitbishop/board/test_b_get_fen.cpp
+++ b/tests/bitbishop/board/test_b_get_fen.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <bitbishop/board.hpp>
+
+struct FenTestCase {
+  std::string name;
+  std::string fen;
+};
+
+class BoardGetFenTest : public ::testing::TestWithParam<FenTestCase> {};
+
+TEST_P(BoardGetFenTest, ReturnsSameFen) {
+  const auto& param = GetParam();
+  Board board(param.fen);
+
+  EXPECT_EQ(board.get_fen(), param.fen);
+}
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(
+    GetFenTests,
+    BoardGetFenTest,
+    ::testing::Values(
+        FenTestCase{
+            "EmptyBoard",
+            "8/8/8/8/8/8/8/8 w - - 0 1"
+        },
+        FenTestCase{
+            "StartingPosition",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        },
+        FenTestCase{
+            "BlackToMove",
+            "8/8/8/8/8/8/8/8 b - - 0 1"
+        },
+        FenTestCase{
+            "PartialCastling",
+            "8/8/8/8/8/8/8/8 w Kq - 0 1"
+        },
+        FenTestCase{
+            "NoCastling",
+            "8/8/8/8/8/8/8/8 w - - 0 1"
+        },
+        FenTestCase{
+            "EnPassant",
+            "8/8/8/8/8/8/8/8 w - e3 0 1"
+        },
+        FenTestCase{
+            "MoveCounters",
+            "8/8/8/8/8/8/8/8 w - - 17 42"
+        },
+        FenTestCase{
+            "MixedCompression",
+            "8/8/3p4/8/8/4P3/8/8 w - - 0 1"
+        }
+    ),
+    [](const testing::TestParamInfo<FenTestCase>& info) {
+        return info.param.name;
+    }
+);
+// clang-format on

--- a/tests/bitbishop/board/test_b_print.cpp
+++ b/tests/bitbishop/board/test_b_print.cpp
@@ -7,10 +7,12 @@
 
 /**
  * @test BoardTest.PrintBoard
- * @brief Verifies that the board prints in correct ASCII format.
+ * @brief Verifies that the board prints to std::cout correctly when called from a starting position.
+ *
+ * @note Uses operator<< that already test for formatting correctness.
  */
-TEST(BoardTest, PrintBoard) {
-  Board board;
+TEST(BoardTest, PrintBoardStartingPos) {
+  Board board = Board::StartingPosition();
 
   std::ostringstream oss;
   // Redirect std::cout to oss
@@ -21,15 +23,25 @@ TEST(BoardTest, PrintBoard) {
   std::string output = oss.str();
 
   std::string expected =
-      "8 r n b q k b n r \n"
-      "7 p p p p p p p p \n"
-      "6 . . . . . . . . \n"
-      "5 . . . . . . . . \n"
-      "4 . . . . . . . . \n"
-      "3 . . . . . . . . \n"
-      "2 P P P P P P P P \n"
-      "1 R N B Q K B N R \n"
-      "  a b c d e f g h\n";
+      "     a   b   c   d   e   f   g   h  \n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 8 | r | n | b | q | k | b | n | r | 8\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 7 | p | p | p | p | p | p | p | p | 7\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 6 |   |   |   |   |   |   |   |   | 6\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 5 |   |   |   |   |   |   |   |   | 5\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 4 |   |   |   |   |   |   |   |   | 4\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 3 |   |   |   |   |   |   |   |   | 3\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 2 | P | P | P | P | P | P | P | P | 2\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 1 | R | N | B | Q | K | B | N | R | 1\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      "     a   b   c   d   e   f   g   h  \n";
 
   EXPECT_EQ(output, expected);
 }

--- a/tests/bitbishop/board/test_b_stream_ops.cpp
+++ b/tests/bitbishop/board/test_b_stream_ops.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <bitbishop/board.hpp>
+
+TEST(BoardTestOStreamOverload, EmptyBoardProvidesCorrectFormatting) {
+  std::ostringstream oss;
+
+  Board board = Board::Empty();
+
+  oss << board;
+
+  std::string expected =
+      "     a   b   c   d   e   f   g   h  \n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 8 |   |   |   |   |   |   |   |   | 8\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 7 |   |   |   |   |   |   |   |   | 7\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 6 |   |   |   |   |   |   |   |   | 6\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 5 |   |   |   |   |   |   |   |   | 5\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 4 |   |   |   |   |   |   |   |   | 4\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 3 |   |   |   |   |   |   |   |   | 3\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 2 |   |   |   |   |   |   |   |   | 2\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 1 |   |   |   |   |   |   |   |   | 1\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      "     a   b   c   d   e   f   g   h  \n";
+
+  ASSERT_EQ(oss.str(), expected);
+}
+
+TEST(BoardTestOStreamOverload, StartingPositionBoardProvidesCorrectFormatting) {
+  std::ostringstream oss;
+
+  Board board = Board::StartingPosition();
+
+  oss << board;
+
+  std::string expected =
+      "     a   b   c   d   e   f   g   h  \n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 8 | r | n | b | q | k | b | n | r | 8\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 7 | p | p | p | p | p | p | p | p | 7\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 6 |   |   |   |   |   |   |   |   | 6\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 5 |   |   |   |   |   |   |   |   | 5\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 4 |   |   |   |   |   |   |   |   | 4\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 3 |   |   |   |   |   |   |   |   | 3\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 2 | P | P | P | P | P | P | P | P | 2\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 1 | R | N | B | Q | K | B | N | R | 1\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      "     a   b   c   d   e   f   g   h  \n";
+
+  ASSERT_EQ(oss.str(), expected);
+}
+
+TEST(BoardTestOStreamOverload, RandomPositionBoardProvidesCorrectFormatting) {
+  std::ostringstream oss;
+
+  Board board("rk2n1qr/ppppp1pp/1bn2b2/2NQp2P/8/2B4B/PPPPPP1P/RK1N3R b - - 0 1");
+
+  oss << board;
+
+  std::string expected =
+      "     a   b   c   d   e   f   g   h  \n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 8 | r | k |   |   | n |   | q | r | 8\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 7 | p | p | p | p | p |   | p | p | 7\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 6 |   | b | n |   |   | b |   |   | 6\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 5 |   |   | N | Q | p |   |   | P | 5\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 4 |   |   |   |   |   |   |   |   | 4\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 3 |   |   | B |   |   |   |   | B | 3\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 2 | P | P | P | P | P | P |   | P | 2\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      " 1 | R | K |   | N |   |   |   | R | 1\n"
+      "   +---+---+---+---+---+---+---+---+\n"
+      "     a   b   c   d   e   f   g   h  \n";
+
+  ASSERT_EQ(oss.str(), expected);
+}

--- a/tests/bitbishop/interface/test_uci_engine.cpp
+++ b/tests/bitbishop/interface/test_uci_engine.cpp
@@ -437,3 +437,34 @@ TEST_F(UciEngineTest, EngineStopsOnInputCloseEOF) {
 
   SUCCEED();
 }
+
+void assert_display_works(const std::stringstream& output) {
+  assert_output_contains(output, "+---+---+---+---+---+---+---+---+");
+  assert_output_contains(output, "  a   b   c   d   e   f   g   h  ");
+  assert_output_contains(output, "FEN notation");
+  assert_output_contains(output, "Zobrist hash");
+}
+
+TEST_F(UciEngineTest, DisplayWorksWithStartPos) {
+  input.write(
+      "position startpos\n"
+      "d\n");
+
+  assert_display_works(output);
+}
+
+TEST_F(UciEngineTest, DisplayWorksWithRandomPosition) {
+  input.write(
+      "position fen rk2n1qr/ppppp1pp/1bn2b2/2NQp2P/8/2B4B/PPPPPP1P/RK1N3R b - - 0 1\n"
+      "d\n");
+
+  assert_display_works(output);
+}
+
+TEST_F(UciEngineTest, DisplayWorksWithEmptyBoard) {
+  input.write(
+      "position fen 8/8/8/8/8/8/8/8 b - - 0 1\n"
+      "d\n");
+
+  assert_display_works(output);
+}


### PR DESCRIPTION
# 📌 Implementing UCI `d` command

## 📄 Description

- Added `Board.get_fen()` to rebuild a FEN from a given board state
- Added output stream operator overload for Board class for easy export to any kind of output stream
- Added the UCI command `d` to display information about the current internal board state

## 🧩 Type of Change

- ✨ New feature
- ✅ Test addition or update