### PR TITLE
Updating GitHub action dependencies

### DIFF
--- a/.github/actions/_setup_configure_build_linux/action.yaml
+++ b/.github/actions/_setup_configure_build_linux/action.yaml
@@ -44,7 +44,7 @@ runs:
         } >> "$GITHUB_ENV"
 
     - name: Cache VCPKG assets
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           .cache/vcpkg/downloads
@@ -53,7 +53,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.arch }}-vcpkg-
 
     - name: Cache build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/${{ inputs.build-preset }}
         key: ${{ runner.os }}-${{ inputs.arch }}-cmake-${{ inputs.build-preset }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'vcpkg.json', '**/*.cmake', '.github/actions/_setup_configure_build_linux/action.yaml') }}

--- a/.github/actions/_setup_configure_build_macos/action.yaml
+++ b/.github/actions/_setup_configure_build_macos/action.yaml
@@ -44,7 +44,7 @@ runs:
         } >> "$GITHUB_ENV"
 
     - name: Cache VCPKG assets
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           .cache/vcpkg/downloads
@@ -53,7 +53,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.arch }}-vcpkg-
 
     - name: Cache build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/${{ inputs.build-preset }}
         key: ${{ runner.os }}-${{ inputs.arch }}-cmake-${{ inputs.build-preset }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'vcpkg.json', '**/*.cmake', '.github/actions/_setup_configure_build_macos/action.yaml') }}

--- a/.github/actions/_setup_configure_build_windows/action.yaml
+++ b/.github/actions/_setup_configure_build_windows/action.yaml
@@ -43,7 +43,7 @@ runs:
         ) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Cache VCPKG assets
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           .cache/vcpkg/downloads
@@ -52,7 +52,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.arch }}-vcpkg-
 
     - name: Cache build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: build/${{ inputs.build-preset }}
         key: ${{ runner.os }}-${{ inputs.arch }}-cmake-${{ inputs.build-preset }}-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'vcpkg.json', '**/*.cmake', '.github/actions/_setup_configure_build_windows/action.yaml') }}

--- a/.github/workflows/clang_tidy.yaml
+++ b/.github/workflows/clang_tidy.yaml
@@ -29,7 +29,7 @@ jobs:
             build_preset: clang_debug
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup, configure, and run clang-tidy
         uses: ./.github/actions/_setup_configure_build_linux

--- a/.github/workflows/linux_build_test.yaml
+++ b/.github/workflows/linux_build_test.yaml
@@ -69,7 +69,7 @@ jobs:
       matrix: ${{ fromJson(needs.plan-linux-build.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup, configure, and build Linux CI
         uses: ./.github/actions/_setup_configure_build_linux

--- a/.github/workflows/macos_build_test.yaml
+++ b/.github/workflows/macos_build_test.yaml
@@ -36,7 +36,7 @@ jobs:
             test_preset: quick-validation-clang-release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup, configure, and build macOS CI
         uses: ./.github/actions/_setup_configure_build_macos

--- a/.github/workflows/publish_llvm_coverage.yaml
+++ b/.github/workflows/publish_llvm_coverage.yaml
@@ -18,7 +18,7 @@ jobs:
     name: ubuntu-24.04-arm - quick-validation-clang-debug
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup, configure, and build Linux CI
         uses: ./.github/actions/_setup_configure_build_linux

--- a/.github/workflows/windows_build_test.yaml
+++ b/.github/workflows/windows_build_test.yaml
@@ -41,7 +41,7 @@ jobs:
             test_preset: quick-validation-msvc-release-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup, configure, and build Windows CI
         uses: ./.github/actions/_setup_configure_build_windows


### PR DESCRIPTION
# 📌 Updating GitHub action dependencies

## 📄 Description

- Updated `actions/checkout` from `v4` to `v6`
- Updated `actions/cache` from `v4` to `v5`

## 🧩 Type of Change

- 🔧 Build or CI/CD configuration
- 🧹 Code cleanup
